### PR TITLE
request requires us to pass json: true if we want stuff to be parsed …

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ Plaid._publicRequest = function(options, callback) {
   request({
     uri: options.uri,
     method: options.method,
-    json: options.body,
+    json: options.body || true,
   }, function(err, res, $body) {
     if (err != null) {
       callback(err, null);
@@ -287,7 +287,6 @@ Plaid.getCategory = function(category_id, env, callback) {
   this._publicRequest({
     uri: env + '/categories/' + category_id,
     method: 'GET',
-    body: {},
   }, callback);
 };
 
@@ -295,7 +294,6 @@ Plaid.getCategories = function(env, callback) {
   this._publicRequest({
     uri: env + '/categories',
     method: 'GET',
-    body: {},
   }, callback);
 };
 
@@ -303,7 +301,6 @@ Plaid.getInstitution = function(institution_id, env, callback) {
   this._publicRequest({
     uri: env + '/institutions/' + institution_id,
     method: 'GET',
-    body: {},
   }, callback);
 };
 
@@ -311,7 +308,6 @@ Plaid.getInstitutions = function(env, callback) {
   this._publicRequest({
     uri: env + '/institutions',
     method: 'GET',
-    body: {},
   }, callback);
 };
 
@@ -324,7 +320,6 @@ Plaid.searchInstitutions = function(options, env, callback) {
   this._publicRequest({
     uri: env + '/institutions/search?' + qs,
     method: 'GET',
-    body: {},
   }, callback);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plaid",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A node.js client for the Plaid API",
   "keywords": [
     "plaid",


### PR DESCRIPTION
…as json. Since we always want results to be parsed, we fall back to true if there is no body supplied (as should be the case for GET requests). Actually passing a body to _publicRequest can still create an error here.

https://github.com/plaid/plaid-node/pull/81
